### PR TITLE
Ci/one snap per arch

### DIFF
--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -96,7 +96,7 @@ jobs:
           path: /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/${{ matrix.snap_names }}/*.snap
 
   ros-publish:
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -74,6 +74,7 @@ jobs:
           snapcraft-args: "remote-build --launchpad-accept-public-upload --build-id ${{ matrix.snap_names }}-${SNAPCRAFT_BUILDER_ID}"
       - uses: actions/upload-artifact@v3
         name: Upload snapcraft logs
+        if: always()
         with:
           name: snapcraft_logs
           path: |

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -39,7 +39,7 @@ jobs:
           path: snaps/
 
   snap-build:
-    name: Remote building the ros snaps
+    name: Remote build ROS snaps
     needs: generate-snapcrafts
     runs-on: [ubuntu-latest]
     outputs:

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -6,38 +6,69 @@ on:
   workflow_dispatch:
 
 jobs:
-  snap:
+  generate-snapcrafts:
+    name: Generate snapcraft.yaml files
     runs-on: [ubuntu-latest]
-    env:
-      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
-      # snapcraft remote-build will create a repository with the name decided by the --build-id arg
-      # URL to this repo echoed below to help debug builds (does not change if the workflow is re-run)
-      SNAPCRAFT_BUILDER_ID: ${{ matrix.releases }}-${{ matrix.arch }}-${{ github.run_id }}
-    name: Remote building the snaps
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' 
+      - name: Generate snapacraft yaml files for all ros distros
+        id: generate
+        run: |
+          pip install .
+          python3 ./generate_all_ros_meta_snapcraft_file.py
+          echo "matrix=$(python3 ./generate_all_ros_meta_snapcraft_file.py)" >> $GITHUB_OUTPUT
+      - name: Upload snapcrafts folders
+        uses: actions/upload-artifact@v3
+        with:
+          name: snaps
+          path: snaps/
+
+  ros1-snap:
+    name: Remote building the ros1 snaps
+    needs: generate-snapcrafts
+    runs-on: [ubuntu-latest]
+    strategy:
+      matrix:
+        ros1_distros: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix).ros1_distros }}
+        ros1_variants: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix).ros1_variants }}
+    env:
+      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
+      # snapcraft remote-build will create a repository with the name decided by the --build-id arg
+      # URL to this repo echoed below to help debug builds (does not change if the workflow is re-run)
+      SNAPCRAFT_BUILDER_ID: ${{ github.run_id }}
+    steps:
+      - name: Download snapcrafts folders
+        uses: actions/download-artifact@v3
+        with:
+          name: snaps
+      - name: print matrix
+        run: |
+          echo ${{ matrix.ros1_distros }}
+          echo ${{ matrix.ros1_variants }}
+      - name: print matrix
+        run: |
+          echo ${{ matrix.ros1_distros }}
+          echo ${{ matrix.ros1_variants }}
       - name: Add LP credentials
         run: |
           mkdir -p ~/.local/share/snapcraft/provider/launchpad/
           echo '${{ secrets.LP_CREDS }}' > ~/.local/share/snapcraft/provider/launchpad/credentials
           git config --global user.email "canonical-robotics-brand@canonical.com"
           git config --global user.name "Canonical robotics"
-
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10' 
-      - run: |
-          pip install .
-          python3 ./generate_all_ros_meta_snapcraft_file.py
-      # - name: Print Launchpad build repository
-      #   run: |
-      #     echo "Building at: https://git.launchpad.net/~ce-certification-qa/+snap/$SNAPCRAFT_BUILDER_ID"
+      - name: Print Launchpad build repository
+        run: |
+          echo "Building at: https://git.launchpad.net/~ce-certification-qa/+snap/$SNAPCRAFT_BUILDER_ID"
       - uses: snapcore/action-build@v1
         with:
-          path: snaps/foxy_ros_base
-          snapcraft-args: "remote-build --launchpad-accept-public-upload --build-id foxy-ros-base-${SNAPCRAFT_BUILDER_ID}"
+          path: /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/${{ matrix.ros1_distros }}_${{ matrix.ros1_variants }}
+          snapcraft-args: "remote-build --launchpad-accept-public-upload --build-id ${{ matrix.ros1_distros }}-${{ matrix.ros1_variants }}-${SNAPCRAFT_BUILDER_ID}"
       - uses: actions/upload-artifact@v3
         name: Upload snapcraft logs
         with:
@@ -45,9 +76,58 @@ jobs:
           path: |
             /home/runner/.cache/snapcraft/log/
             /home/runner/.local/state/snapcraft/log/
-            snaps/**/ros-*.txt
+            /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/**/ros-*.txt
       - uses: actions/upload-artifact@v3
         name: Upload the snap as artifact
         with:
           name: remote_built_snaps
-          path: snaps/**/*.snap
+          path: /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/**/*.snap
+
+  ros2-snap:
+    name: Remote building the ros2 snaps
+    needs: generate-snapcrafts
+    runs-on: [ubuntu-latest]
+    strategy:
+      matrix:
+        ros2_distros: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix).ros2_distros }}
+        ros2_variants: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix).ros2_variants }}
+    env:
+      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
+      # snapcraft remote-build will create a repository with the name decided by the --build-id arg
+      # URL to this repo echoed below to help debug builds (does not change if the workflow is re-run)
+      SNAPCRAFT_BUILDER_ID: ${{ github.run_id }}
+    steps:
+      - name: Download snapcrafts folders
+        uses: actions/download-artifact@v3
+        with:
+          name: snaps
+      - name: print matrix
+        run: |
+          echo ${{ matrix.ros2_distros }}
+          echo ${{ matrix.ros2_variants }}
+      - name: Add LP credentials
+        run: |
+          mkdir -p ~/.local/share/snapcraft/provider/launchpad/
+          echo '${{ secrets.LP_CREDS }}' > ~/.local/share/snapcraft/provider/launchpad/credentials
+          git config --global user.email "canonical-robotics-brand@canonical.com"
+          git config --global user.name "Canonical robotics"
+      - name: Print Launchpad build repository
+        run: |
+          echo "Building at: https://git.launchpad.net/~ce-certification-qa/+snap/$SNAPCRAFT_BUILDER_ID"
+      - uses: snapcore/action-build@v1
+        with:
+          path: /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/${{ matrix.ros2_distros }}_${{ matrix.ros2_variants }}
+          snapcraft-args: "remote-build --launchpad-accept-public-upload --build-id ${{ matrix.ros2_distros }}-${{ matrix.ros2_variants }}-${SNAPCRAFT_BUILDER_ID}"
+      - uses: actions/upload-artifact@v3
+        name: Upload snapcraft logs
+        with:
+          name: snapcraft_logs
+          path: |
+            /home/runner/.cache/snapcraft/log/
+            /home/runner/.local/state/snapcraft/log/
+            /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/**/ros-*.txt
+      - uses: actions/upload-artifact@v3
+        name: Upload the snap as artifact
+        with:
+          name: remote_built_snaps
+          path: /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/**/*.snap

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -111,4 +111,4 @@ jobs:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
       with:
         snap: ${{ env.SNAPFILE }}
-        release: edge
+        release: beta

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -112,5 +112,5 @@ jobs:
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
       with:
-        snap: ${{needs.build.outputs.snap-file}}
+        snap:  /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/${{ matrix.snap_names }}/*.snap
         release: ${{ startsWith(github.ref, 'refs/tags/') && 'edge'}}

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -3,6 +3,14 @@ name: Monthly builds
 on:
   schedule:
     - cron: '0 0 1 * *'
+  push:
+    tags:
+      - '*'
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
@@ -35,6 +43,7 @@ jobs:
     needs: generate-snapcrafts
     runs-on: [ubuntu-latest]
     strategy:
+      fail-fast: false
       matrix:
         ros1_distros: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix).ros1_distros }}
         ros1_variants: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix).ros1_variants }}
@@ -88,6 +97,7 @@ jobs:
     needs: generate-snapcrafts
     runs-on: [ubuntu-latest]
     strategy:
+      fail-fast: false
       matrix:
         ros2_distros: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix).ros2_distros }}
         ros2_variants: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix).ros2_variants }}

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -38,6 +38,15 @@ jobs:
         with:
           path: snaps/foxy_ros_base
           snapcraft-args: "remote-build --launchpad-accept-public-upload --build-id foxy-ros-base-${SNAPCRAFT_BUILDER_ID}"
+
+      - uses: actions/upload-artifact@v3
+        name: Upload snapcraft logs
+        with:
+          name: snapcraft logs
+          path: |
+            /home/runner/.cache/snapcraft/log/
+            /home/runner/.local/state/snapcraft/log/
+            snaps/**/ros-*.txt
       - uses: actions/upload-artifact@v3
         name: Upload the snap as artifact
         with:

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -47,7 +47,6 @@ jobs:
       matrix:
         snap_names: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix) }}
     env:
-      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
       # snapcraft remote-build will create a repository with the name decided by the --build-id arg
       # URL to this repo echoed below to help debug builds (does not change if the workflow is re-run)
       SNAPCRAFT_BUILDER_ID: ${{ github.run_id }}

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -114,5 +114,5 @@ jobs:
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
       with:
-        snap: ${{ env.TAG }}
-        release: ${{ startsWith(github.ref, 'refs/tags/') && 'edge'}}
+        snap: ${{ env.SNAPFILE }}
+        release: edge

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -1,0 +1,45 @@
+name: Monthly builds
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+jobs:
+  snap:
+    runs-on: [ubuntu-latest]
+    env:
+      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
+      # snapcraft remote-build will create a repository with the name decided by the --build-id arg
+      # URL to this repo echoed below to help debug builds (does not change if the workflow is re-run)
+      SNAPCRAFT_BUILDER_ID: ${{ matrix.releases }}-${{ matrix.arch }}-${{ github.run_id }}
+    name: Runtime (Core) ${{ matrix.releases }}-${{ matrix.arch }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Add LP credentials
+        run: |
+          mkdir -p ~/.local/share/snapcraft/provider/launchpad/
+          echo '${{ secrets.LP_CREDS }}' > ~/.local/share/snapcraft/provider/launchpad/credentials
+          git config --global user.email "canonical-robotics-brand@canonical.com"
+          git config --global user.name "Canonical robotics"
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' 
+      - run: |
+          pip install .
+          python3 ./generate_all_ros_meta_snapcraft_file.py
+      # - name: Print Launchpad build repository
+      #   run: |
+      #     echo "Building at: https://git.launchpad.net/~ce-certification-qa/+snap/$SNAPCRAFT_BUILDER_ID"
+      - uses: snapcore/action-build@v1
+        with:
+          path: snaps/foxy_ros_base
+          snapcraft-args: "--remote-build --launchpad-accept-public-upload --build-id foxy-ros-base-${SNAPCRAFT_BUILDER_ID}"
+      - uses: actions/upload-artifact@v3
+        name: Upload the snap as artifact
+        with:
+          name: remote-built snaps
+          path: snaps/**/*.snap

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -56,9 +56,6 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: snaps
-      - name: print matrix
-        run: |
-          echo ${{ matrix.snap_names }}
       - name: Add LP credentials
         run: |
           mkdir -p ~/.local/share/snapcraft/provider/launchpad/

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -42,8 +42,6 @@ jobs:
     name: Remote build ROS snaps
     needs: generate-snapcrafts
     runs-on: [ubuntu-latest]
-    outputs:
-      snap-file: ${{ steps.build-snap.outputs.snap }}
     strategy:
       fail-fast: false
       matrix:
@@ -95,7 +93,7 @@ jobs:
         name: Upload the snap as artifact
         with:
           name: ${{ matrix.snap_names }}
-          path: ${{ steps.build-snap.outputs.snap }}
+          path: /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/${{ matrix.snap_names }}/*.snap
 
   ros-publish:
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -31,22 +31,21 @@ jobs:
         run: |
           pip install .
           python3 ./generate_all_ros_meta_snapcraft_file.py
-          echo "matrix=$(python3 ./generate_all_ros_meta_snapcraft_file.py)" >> $GITHUB_OUTPUT
+          echo "matrix=$(ls snaps/ | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
       - name: Upload snapcrafts folders
         uses: actions/upload-artifact@v3
         with:
           name: snaps
           path: snaps/
 
-  ros1-snap:
+  snap-build:
     name: Remote building the ros1 snaps
     needs: generate-snapcrafts
     runs-on: [ubuntu-latest]
     strategy:
       fail-fast: false
       matrix:
-        ros1_distros: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix).ros1_distros }}
-        ros1_variants: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix).ros1_variants }}
+        snap_names: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix) }}
     env:
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
       # snapcraft remote-build will create a repository with the name decided by the --build-id arg
@@ -59,12 +58,7 @@ jobs:
           name: snaps
       - name: print matrix
         run: |
-          echo ${{ matrix.ros1_distros }}
-          echo ${{ matrix.ros1_variants }}
-      - name: print matrix
-        run: |
-          echo ${{ matrix.ros1_distros }}
-          echo ${{ matrix.ros1_variants }}
+          echo ${{ matrix.snap_names }}
       - name: Add LP credentials
         run: |
           mkdir -p ~/.local/share/snapcraft/provider/launchpad/
@@ -76,8 +70,8 @@ jobs:
           echo "Building at: https://git.launchpad.net/~ce-certification-qa/+snap/$SNAPCRAFT_BUILDER_ID"
       - uses: snapcore/action-build@v1
         with:
-          path: /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/${{ matrix.ros1_distros }}_${{ matrix.ros1_variants }}
-          snapcraft-args: "remote-build --launchpad-accept-public-upload --build-id ${{ matrix.ros1_distros }}-${{ matrix.ros1_variants }}-${SNAPCRAFT_BUILDER_ID}"
+          path: /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/${{ matrix.snap_names }}
+          snapcraft-args: "remote-build --launchpad-accept-public-upload --build-id ${{ matrix.snap_names }}-${SNAPCRAFT_BUILDER_ID}"
       - uses: actions/upload-artifact@v3
         name: Upload snapcraft logs
         with:
@@ -89,55 +83,76 @@ jobs:
       - uses: actions/upload-artifact@v3
         name: Upload the snap as artifact
         with:
-          name: remote_built_snaps
+          name: ${{ matrix.snap_names }}
           path: /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/**/*.snap
 
-  ros2-snap:
-    name: Remote building the ros2 snaps
-    needs: generate-snapcrafts
-    runs-on: [ubuntu-latest]
-    strategy:
-      fail-fast: false
-      matrix:
-        ros2_distros: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix).ros2_distros }}
-        ros2_variants: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix).ros2_variants }}
-    env:
-      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
-      # snapcraft remote-build will create a repository with the name decided by the --build-id arg
-      # URL to this repo echoed below to help debug builds (does not change if the workflow is re-run)
-      SNAPCRAFT_BUILDER_ID: ${{ github.run_id }}
-    steps:
-      - name: Download snapcrafts folders
-        uses: actions/download-artifact@v3
-        with:
-          name: snaps
-      - name: print matrix
-        run: |
-          echo ${{ matrix.ros2_distros }}
-          echo ${{ matrix.ros2_variants }}
-      - name: Add LP credentials
-        run: |
-          mkdir -p ~/.local/share/snapcraft/provider/launchpad/
-          echo '${{ secrets.LP_CREDS }}' > ~/.local/share/snapcraft/provider/launchpad/credentials
-          git config --global user.email "canonical-robotics-brand@canonical.com"
-          git config --global user.name "Canonical robotics"
-      - name: Print Launchpad build repository
-        run: |
-          echo "Building at: https://git.launchpad.net/~ce-certification-qa/+snap/$SNAPCRAFT_BUILDER_ID"
-      - uses: snapcore/action-build@v1
-        with:
-          path: /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/${{ matrix.ros2_distros }}_${{ matrix.ros2_variants }}
-          snapcraft-args: "remote-build --launchpad-accept-public-upload --build-id ${{ matrix.ros2_distros }}-${{ matrix.ros2_variants }}-${SNAPCRAFT_BUILDER_ID}"
-      - uses: actions/upload-artifact@v3
-        name: Upload snapcraft logs
-        with:
-          name: snapcraft_logs
-          path: |
-            /home/runner/.cache/snapcraft/log/
-            /home/runner/.local/state/snapcraft/log/
-            /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/**/ros-*.txt
-      - uses: actions/upload-artifact@v3
-        name: Upload the snap as artifact
-        with:
-          name: remote_built_snaps
-          path: /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/**/*.snap
+  # ros2-build:
+  #   name: Remote building the ros2 snaps
+  #   needs: generate-snapcrafts
+  #   runs-on: [ubuntu-latest]
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       ros2_distros: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix).ros2_distros }}
+  #       ros2_variants: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix).ros2_variants }}
+  #   env:
+  #     SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
+  #     # snapcraft remote-build will create a repository with the name decided by the --build-id arg
+  #     # URL to this repo echoed below to help debug builds (does not change if the workflow is re-run)
+  #     SNAPCRAFT_BUILDER_ID: ${{ github.run_id }}
+  #   steps:
+  #     - name: Download snapcrafts folders
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: snaps
+  #     - name: print matrix
+  #       run: |
+  #         echo ${{ matrix.ros2_distros }}
+  #         echo ${{ matrix.ros2_variants }}
+  #     - name: Add LP credentials
+  #       run: |
+  #         mkdir -p ~/.local/share/snapcraft/provider/launchpad/
+  #         echo '${{ secrets.LP_CREDS }}' > ~/.local/share/snapcraft/provider/launchpad/credentials
+  #         git config --global user.email "canonical-robotics-brand@canonical.com"
+  #         git config --global user.name "Canonical robotics"
+  #     - name: Print Launchpad build repository
+  #       run: |
+  #         echo "Building at: https://git.launchpad.net/~ce-certification-qa/+snap/$SNAPCRAFT_BUILDER_ID"
+  #     - uses: snapcore/action-build@v1
+  #       with:
+  #         path: /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/${{ matrix.ros2_distros }}_${{ matrix.ros2_variants }}
+  #         snapcraft-args: "remote-build --launchpad-accept-public-upload --build-id ${{ matrix.ros2_distros }}-${{ matrix.ros2_variants }}-${SNAPCRAFT_BUILDER_ID}"
+  #     - uses: actions/upload-artifact@v3
+  #       name: Upload snapcraft logs
+  #       with:
+  #         name: snapcraft_logs
+  #         path: |
+  #           /home/runner/.cache/snapcraft/log/
+  #           /home/runner/.local/state/snapcraft/log/
+  #           /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/**/ros-*.txt
+  #     - uses: actions/upload-artifact@v3
+  #       name: Upload the snap as artifact
+  #       with:
+  #         name: ${{ matrix.ros2_distros }}-${{ matrix.ros2_variants }}
+  #         path: /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/**/*.snap
+
+  # ros1-publish:
+  #   if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       ros1_distros: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix).ros1_distros }}
+  #       ros1_variants: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix).ros1_variants }}
+  #   needs: ros1-snap
+  #   steps:
+  #   - uses: actions/download-artifact@v3
+  #     with:
+  #       name: remote_built_snaps
+  #       path: .
+  #   - uses: snapcore/action-publish@v1
+  #     env:
+  #       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+  #     with:
+  #       snap: ${{needs.build.outputs.snap-file}}
+  #       release: 'candidate'

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -42,6 +42,8 @@ jobs:
     name: Remote building the ros1 snaps
     needs: generate-snapcrafts
     runs-on: [ubuntu-latest]
+    # outputs:
+    #   matrix: ${{ steps.ros1-upload-generate.outputs.matrix }}
     strategy:
       fail-fast: false
       matrix:
@@ -86,56 +88,10 @@ jobs:
         with:
           name: ${{ matrix.snap_names }}
           path: /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/**/*.snap
-
-  # ros2-build:
-  #   name: Remote building the ros2 snaps
-  #   needs: generate-snapcrafts
-  #   runs-on: [ubuntu-latest]
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       ros2_distros: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix).ros2_distros }}
-  #       ros2_variants: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix).ros2_variants }}
-  #   env:
-  #     SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT7_CREDS }}
-  #     # snapcraft remote-build will create a repository with the name decided by the --build-id arg
-  #     # URL to this repo echoed below to help debug builds (does not change if the workflow is re-run)
-  #     SNAPCRAFT_BUILDER_ID: ${{ github.run_id }}
-  #   steps:
-  #     - name: Download snapcrafts folders
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: snaps
-  #     - name: print matrix
-  #       run: |
-  #         echo ${{ matrix.ros2_distros }}
-  #         echo ${{ matrix.ros2_variants }}
-  #     - name: Add LP credentials
-  #       run: |
-  #         mkdir -p ~/.local/share/snapcraft/provider/launchpad/
-  #         echo '${{ secrets.LP_CREDS }}' > ~/.local/share/snapcraft/provider/launchpad/credentials
-  #         git config --global user.email "canonical-robotics-brand@canonical.com"
-  #         git config --global user.name "Canonical robotics"
-  #     - name: Print Launchpad build repository
-  #       run: |
-  #         echo "Building at: https://git.launchpad.net/~ce-certification-qa/+snap/$SNAPCRAFT_BUILDER_ID"
-  #     - uses: snapcore/action-build@v1
-  #       with:
-  #         path: /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/${{ matrix.ros2_distros }}_${{ matrix.ros2_variants }}
-  #         snapcraft-args: "remote-build --launchpad-accept-public-upload --build-id ${{ matrix.ros2_distros }}-${{ matrix.ros2_variants }}-${SNAPCRAFT_BUILDER_ID}"
-  #     - uses: actions/upload-artifact@v3
-  #       name: Upload snapcraft logs
-  #       with:
-  #         name: snapcraft_logs
-  #         path: |
-  #           /home/runner/.cache/snapcraft/log/
-  #           /home/runner/.local/state/snapcraft/log/
-  #           /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/**/ros-*.txt
-  #     - uses: actions/upload-artifact@v3
-  #       name: Upload the snap as artifact
-  #       with:
-  #         name: ${{ matrix.ros2_distros }}-${{ matrix.ros2_variants }}
-  #         path: /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/**/*.snap
+      # - name: Generate matrix for upload
+      #   id: ros1-upload-generate
+      #   run: |
+      #     echo "matrix=$(ls snaps/ | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
 
   # ros1-publish:
   #   if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -108,9 +108,11 @@ jobs:
       with:
         name: ${{ matrix.snap_names }}
         path: .
+    - name: Get snap filename
+      run: echo "SNAPFILE=$(ls *.snap)" >> $GITHUB_ENV
     - uses: snapcore/action-publish@v1
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
       with:
-        snap:  /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/${{ matrix.snap_names }}/*.snap
+        snap: ${{ env.TAG }}
         release: ${{ startsWith(github.ref, 'refs/tags/') && 'edge'}}

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -13,7 +13,7 @@ jobs:
       # snapcraft remote-build will create a repository with the name decided by the --build-id arg
       # URL to this repo echoed below to help debug builds (does not change if the workflow is re-run)
       SNAPCRAFT_BUILDER_ID: ${{ matrix.releases }}-${{ matrix.arch }}-${{ github.run_id }}
-    name: Runtime (Core) ${{ matrix.releases }}-${{ matrix.arch }}
+    name: Remote building the snaps
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,7 +37,7 @@ jobs:
       - uses: snapcore/action-build@v1
         with:
           path: snaps/foxy_ros_base
-          snapcraft-args: "--remote-build --launchpad-accept-public-upload --build-id foxy-ros-base-${SNAPCRAFT_BUILDER_ID}"
+          snapcraft-args: "remote-build --launchpad-accept-public-upload --build-id foxy-ros-base-${SNAPCRAFT_BUILDER_ID}"
       - uses: actions/upload-artifact@v3
         name: Upload the snap as artifact
         with:

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -39,11 +39,11 @@ jobs:
           path: snaps/
 
   snap-build:
-    name: Remote building the ros1 snaps
+    name: Remote building the ros snaps
     needs: generate-snapcrafts
     runs-on: [ubuntu-latest]
-    # outputs:
-    #   matrix: ${{ steps.ros1-upload-generate.outputs.matrix }}
+    outputs:
+      snap-file: ${{ steps.build-snap.outputs.snap }}
     strategy:
       fail-fast: false
       matrix:
@@ -95,29 +95,24 @@ jobs:
         name: Upload the snap as artifact
         with:
           name: ${{ matrix.snap_names }}
-          path: /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/**/*.snap
-      # - name: Generate matrix for upload
-      #   id: ros1-upload-generate
-      #   run: |
-      #     echo "matrix=$(ls snaps/ | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          path: ${{ steps.build-snap.outputs.snap }}
 
-  # ros1-publish:
-  #   if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       ros1_distros: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix).ros1_distros }}
-  #       ros1_variants: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix).ros1_variants }}
-  #   needs: ros1-snap
-  #   steps:
-  #   - uses: actions/download-artifact@v3
-  #     with:
-  #       name: remote_built_snaps
-  #       path: .
-  #   - uses: snapcore/action-publish@v1
-  #     env:
-  #       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
-  #     with:
-  #       snap: ${{needs.build.outputs.snap-file}}
-  #       release: 'candidate'
+  ros-publish:
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        snap_names: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix) }}
+    needs: snap-build
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: ${{ matrix.snap_names }}
+        path: .
+    - uses: snapcore/action-publish@v1
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+      with:
+        snap: ${{needs.build.outputs.snap-file}}
+        release: ${{ startsWith(github.ref, 'refs/tags/') && 'edge'}}

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -98,11 +98,11 @@ jobs:
   ros-publish:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    needs: [generate-snapcrafts, snap-build]
     strategy:
       fail-fast: false
       matrix:
         snap_names: ${{ fromJSON(needs.generate-snapcrafts.outputs.matrix) }}
-    needs: snap-build
     steps:
     - uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -38,7 +38,6 @@ jobs:
         with:
           path: snaps/foxy_ros_base
           snapcraft-args: "remote-build --launchpad-accept-public-upload --build-id foxy-ros-base-${SNAPCRAFT_BUILDER_ID}"
-
       - uses: actions/upload-artifact@v3
         name: Upload snapcraft logs
         with:

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         name: Upload snapcraft logs
         with:
-          name: snapcraft logs
+          name: snapcraft_logs
           path: |
             /home/runner/.cache/snapcraft/log/
             /home/runner/.local/state/snapcraft/log/
@@ -49,5 +49,5 @@ jobs:
       - uses: actions/upload-artifact@v3
         name: Upload the snap as artifact
         with:
-          name: remote-built snaps
+          name: remote_built_snaps
           path: snaps/**/*.snap

--- a/.github/workflows/monthly-builds.yaml
+++ b/.github/workflows/monthly-builds.yaml
@@ -74,6 +74,14 @@ jobs:
         with:
           path: /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/${{ matrix.snap_names }}
           snapcraft-args: "remote-build --launchpad-accept-public-upload --build-id ${{ matrix.snap_names }}-${SNAPCRAFT_BUILDER_ID}"
+      - name: check number of built snaps
+        run: |
+          count_txt_files=$(find /home/runner/work/ros-content-sharing-snaps/ros-content-sharing-snaps/${{ matrix.snap_names }} -type f -name 'ros-*.txt' | wc -l)
+          count_snap_files=$(find ${{ matrix.snap_names }} -type f -name '*.snap' | wc -l)
+          if [ "$count_txt_files" -ne "$count_snap_files" ]; then
+            echo "Error: The number of '.txt' files and '.snap' files do not match."
+            exit 1
+          fi
       - uses: actions/upload-artifact@v3
         name: Upload snapcraft logs
         if: always()

--- a/generate_all_ros_meta_snapcraft_file.py
+++ b/generate_all_ros_meta_snapcraft_file.py
@@ -34,7 +34,13 @@ def main(args=None):
     if not parsed_args.path:
         parsed_args.path = Path("snaps")
         os.makedirs(parsed_args.path, exist_ok=True)
+ 
+    versionmap={"noetic":"1", "foxy":"2", "humble":"2"}
 
+    arch_matrix={
+        "1": ["amd64", "arm64", "armhf"],
+        "2": ["amd64", "arm64"],
+    }
 
     matrix={ 
         "noetic": ["ros-core", "ros-base", "robot", "desktop"],
@@ -42,35 +48,29 @@ def main(args=None):
         "humble": ["ros-core", "ros-base", "desktop"],
     }
  
-    github_action_matrix={
-        "ros1_distros": ["noetic"],
-        "ros1_variants": ["ros_core", "ros_base", "robot", "desktop"],
-        "ros2_distros": ["foxy", "humble"],
-        "ros2_variants": ["ros_core", "ros_base", "desktop"],
-    }
-
-    matrix_json = json.dumps(github_action_matrix)
-    print(matrix_json)
-
     for rosdistro, variants in matrix.items():
         for variant in variants:
+            arch_names = arch_matrix[versionmap[rosdistro]]
+            print(arch_names)
+            for arch_name in arch_names:
+                folders = [
+                    parsed_args.path / f'{rosdistro}-{variant}-{arch_name}',
+                    parsed_args.path / f'{rosdistro}-{variant}-{arch_name}-dev'
+                ]
+                print(f'{rosdistro}-{variant}-{arch_name}')
 
-            folders = [
-                parsed_args.path / f'{rosdistro}-{variant}',
-                parsed_args.path / f'{rosdistro}-{variant}-dev'
-            ]
+                for folder in folders:
+                    print(folder)
 
-            for folder in folders:
+                    os.makedirs(folder, exist_ok=True)
 
-                os.makedirs(folder, exist_ok=True)
+                    gen_args = ["-r", rosdistro, "-v", variant, "-p", str(folder), "-q"]
+                    if "dev" in folder.stem:
+                        gen_args.append("-d")
+                    if parsed_args.snap:
+                        gen_args.append("-s")
 
-                gen_args = ["-r", rosdistro, "-v", variant, "-p", str(folder), "-q"]
-                if "dev" in folder.stem:
-                    gen_args.append("-d")
-                if parsed_args.snap:
-                    gen_args.append("-s")
-
-                gen(gen_args)
+                    gen(gen_args)
 
 
 if __name__ == "__main__":

--- a/generate_all_ros_meta_snapcraft_file.py
+++ b/generate_all_ros_meta_snapcraft_file.py
@@ -51,20 +51,15 @@ def main(args=None):
     for rosdistro, variants in matrix.items():
         for variant in variants:
             arch_names = arch_matrix[versionmap[rosdistro]]
-            print(arch_names)
             for arch_name in arch_names:
                 folders = [
                     parsed_args.path / f'{rosdistro}-{variant}-{arch_name}',
                     parsed_args.path / f'{rosdistro}-{variant}-{arch_name}-dev'
                 ]
-                print(f'{rosdistro}-{variant}-{arch_name}')
 
                 for folder in folders:
-                    print(folder)
-
                     os.makedirs(folder, exist_ok=True)
-
-                    gen_args = ["-r", rosdistro, "-v", variant, "-p", str(folder), "-q"]
+                    gen_args = ["-r", rosdistro, "-v", variant, "-a", arch_name, "-p", str(folder), "-q"]
                     if "dev" in folder.stem:
                         gen_args.append("-d")
                     if parsed_args.snap:

--- a/generate_all_ros_meta_snapcraft_file.py
+++ b/generate_all_ros_meta_snapcraft_file.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 from pathlib import Path
+import json
 
 from generate_ros_meta_snapcraft_file import main as gen
 
@@ -35,11 +36,21 @@ def main(args=None):
         os.makedirs(parsed_args.path, exist_ok=True)
 
 
-    matrix={
+    matrix={ 
         "noetic": ["ros-core", "ros-base", "robot", "desktop"],
         "foxy": ["ros-core", "ros-base", "desktop"],
         "humble": ["ros-core", "ros-base", "desktop"],
     }
+ 
+    github_action_matrix={
+        "ros1_distros": ["noetic"],
+        "ros1_variants": ["ros_core", "ros_base", "robot", "desktop"],
+        "ros2_distros": ["foxy", "humble"],
+        "ros2_variants": ["ros_core", "ros_base", "desktop"],
+    }
+
+    matrix_json = json.dumps(github_action_matrix)
+    print(matrix_json)
 
     for rosdistro, variants in matrix.items():
         for variant in variants:
@@ -64,4 +75,3 @@ def main(args=None):
 
 if __name__ == "__main__":
     main()
-

--- a/generate_all_ros_meta_snapcraft_file.py
+++ b/generate_all_ros_meta_snapcraft_file.py
@@ -56,8 +56,8 @@ def main(args=None):
         for variant in variants:
 
             folders = [
-                parsed_args.path / f'{rosdistro}_{variant.replace("-", "_")}',
-                parsed_args.path / f'{rosdistro}_{variant.replace("-", "_")}_dev'
+                parsed_args.path / f'{rosdistro}-{variant}',
+                parsed_args.path / f'{rosdistro}-{variant}-dev'
             ]
 
             for folder in folders:

--- a/generate_ros_meta_snapcraft_file.py
+++ b/generate_ros_meta_snapcraft_file.py
@@ -39,6 +39,14 @@ def main(args=None):
         help="The ROS metapackage to serve as a baseline. (default: %(default)s).",
     )
     parser.add_argument(
+        "-a",
+        "--architecture",
+        type=str,
+        required=True,
+        choices=("amd64", "arm64", "armhf"),
+        help="The snap architecture to target.",
+    )
+    parser.add_argument(
         "-p",
         "--path",
         # type=is_dir,
@@ -68,6 +76,7 @@ def main(args=None):
         template = environment.from_string(f.read())
         snapcraft_file = template.render(
             ros_distro = parsed_args.rosdistro,
+            architecture = parsed_args.architecture,
             variant = parsed_args.variant,
             dev = parsed_args.dev,
         )

--- a/generate_ros_meta_snapcraft_file.py
+++ b/generate_ros_meta_snapcraft_file.py
@@ -1,6 +1,8 @@
 import argparse
 import os
+import shutil
 import subprocess
+
 from pathlib import Path
 
 import jinja2
@@ -60,35 +62,32 @@ def main(args=None):
 
     template_name = "snapcraft.yaml.j2"
 
-    # @todo finish packaging
-    # with pkg_resources.path("rosdk.templates", template_name) as r:
-        # with open(r, "r") as f:
-    if True:
-        with open(Path("templates") / template_name, "r") as f:
-            environment = jinja2.Environment()
-            environment.filters['bool']= bool
-            template = environment.from_string(f.read())
-            snapcraft_file = template.render(
-                ros_distro = parsed_args.rosdistro,
-                variant = parsed_args.variant,
-                dev = parsed_args.dev,
-            )
+    with open(Path("templates") / template_name, "r") as f:
+        environment = jinja2.Environment()
+        environment.filters['bool']= bool
+        template = environment.from_string(f.read())
+        snapcraft_file = template.render(
+            ros_distro = parsed_args.rosdistro,
+            variant = parsed_args.variant,
+            dev = parsed_args.dev,
+        )
+        if not parsed_args.quiet: print(snapcraft_file)
+        if parsed_args.path:
+            if not (os.path.exists(parsed_args.path) and os.path.isdir(parsed_args.path)):
+                raise IsADirectoryError(f"{parsed_args.path} is not a directory!")
+            with open(Path(parsed_args.path) / "snapcraft.yaml", "w") as f:
+                f.write(snapcraft_file)
+            if parsed_args.snap:
+                subprocess.run(
+                    ["snapcraft", "--use-lxd", "--verbose"], check=True,
+                )
 
-            if not parsed_args.quiet: print(snapcraft_file)
+        # add the generate_package_xml_recursive_dependencies.py in case of a dev snap
+        if parsed_args.dev:
+            shutil.copy2("generate_package_xml_recursive_dependencies.py", f"{parsed_args.path}")
 
-            if parsed_args.path:
-                if not (os.path.exists(parsed_args.path) and os.path.isdir(parsed_args.path)):
-                    raise IsADirectoryError(f"{parsed_args.path} is not a directory!")
+        return snapcraft_file
 
-                with open(Path(parsed_args.path) / "snapcraft.yaml", "w") as f:
-                    f.write(snapcraft_file)
-
-                if parsed_args.snap:
-                    subprocess.run(
-                        ["snapcraft", "--use-lxd", "--verbose"], check=True,
-                    )
-
-            return snapcraft_file
 
 if __name__ == "__main__":
     main()

--- a/templates/snapcraft.yaml.j2
+++ b/templates/snapcraft.yaml.j2
@@ -88,12 +88,12 @@ parts:
 {% else %}
       craftctl default
 
-      if [ -f "${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/blas/libblas.so.3."* ]; then
-        ln --symbolic --force --relative "${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/blas/libblas.so.3."* "${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libblas.so.3"
+      if [ -f "${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET}/blas/libblas.so.3."* ]; then
+        ln --symbolic --force --relative "${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET}/blas/libblas.so.3."* "${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libblas.so.3"
       fi
 
-      if [ -f "${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/lapack/liblapack.so.3."* ]; then
-        ln --symbolic --force --relative "${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/lapack/liblapack.so.3."* "${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/liblapack.so.3"
+      if [ -f "${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET}/lapack/liblapack.so.3."* ]; then
+        ln --symbolic --force --relative "${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET}/lapack/liblapack.so.3."* "${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET}/liblapack.so.3"
       fi
 {% endif %}
   cleanup:

--- a/templates/snapcraft.yaml.j2
+++ b/templates/snapcraft.yaml.j2
@@ -36,7 +36,10 @@ package-repositories:
 architectures:
   - build-on: [amd64]
   - build-on: [arm64]
+{%- if versionmap[ros_distro] == '1' %}
   - build-on: [armhf]
+{%- else %}
+
 
 slots:
   ros-{{ ros_distro }}:
@@ -49,7 +52,6 @@ parts:
   variant:
     plugin: {{ pluginmap[ros_distro] }}
     source: ./generate_package_xml_recursive_dependencies.py
-    source-branch: fix/ros2
 {%- if versionmap[ros_distro] == '1' %}
     build-packages: [ros-{{ ros_distro }}-catkin]
 {%- else %}

--- a/templates/snapcraft.yaml.j2
+++ b/templates/snapcraft.yaml.j2
@@ -38,7 +38,7 @@ architectures:
   - build-on: [arm64]
 {%- if versionmap[ros_distro] == '1' %}
   - build-on: [armhf]
-{%- else %}
+{%- endif %}
 
 
 slots:

--- a/templates/snapcraft.yaml.j2
+++ b/templates/snapcraft.yaml.j2
@@ -89,7 +89,7 @@ parts:
       craftctl default
 
       if [ -f "${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET}/blas/libblas.so.3."* ]; then
-        ln --symbolic --force --relative "${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET}/blas/libblas.so.3."* "${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libblas.so.3"
+        ln --symbolic --force --relative "${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET}/blas/libblas.so.3."* "${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET}/libblas.so.3"
       fi
 
       if [ -f "${CRAFT_PART_INSTALL}/usr/lib/${CRAFT_ARCH_TRIPLET}/lapack/liblapack.so.3."* ]; then

--- a/templates/snapcraft.yaml.j2
+++ b/templates/snapcraft.yaml.j2
@@ -34,12 +34,7 @@ package-repositories:
 {%- endif %}
 
 architectures:
-  - build-on: [amd64]
-  - build-on: [arm64]
-{%- if versionmap[ros_distro] == '1' %}
-  - build-on: [armhf]
-{%- endif %}
-
+  - build-on: {{ architecture }}
 
 slots:
   ros-{{ ros_distro }}:

--- a/templates/snapcraft.yaml.j2
+++ b/templates/snapcraft.yaml.j2
@@ -51,7 +51,7 @@ parts:
 {%- if dev is defined and dev | bool %}
   variant:
     plugin: {{ pluginmap[ros_distro] }}
-    source: ./generate_package_xml_recursive_dependencies.py
+    source: .
 {%- if versionmap[ros_distro] == '1' %}
     build-packages: [ros-{{ ros_distro }}-catkin]
 {%- else %}

--- a/templates/snapcraft.yaml.j2
+++ b/templates/snapcraft.yaml.j2
@@ -33,7 +33,10 @@ package-repositories:
     url: http://repo.ros2.org/ubuntu/main
 {%- endif %}
 
-architectures: [amd64, arm64, armhf]
+architectures:
+  - build-on: [amd64]
+  - build-on: [arm64]
+  - build-on: [armhf]
 
 slots:
   ros-{{ ros_distro }}:


### PR DESCRIPTION
One folder and `snapcraft.yaml` is generated for each distro/variant/architecture.

The push was tested [here](https://github.com/ubuntu-robotics/ros-content-sharing-snaps/actions/runs/6888443288).

All the necessary environment variable and secrets are already set in the repo.