### PR TITLE
Rename slots and add new slots for sub-variants

### DIFF
--- a/templates/snapcraft.yaml.j2
+++ b/templates/snapcraft.yaml.j2
@@ -16,13 +16,37 @@ name: {{ snapname }}
 version: '0.1'
 summary: The ROS {{ versionmap[ros_distro] }} {{ ros_distro }} {{ variant }} variant.
 description: |
-  This snap contains the ROS {{ ros_distro }} {{ variant }} variant [1].
-  It is meant to be consumed as a stage or build snap.
+  This snap contains the ROS {{ versionmap[ros_distro] }} {{ ros_distro }} {{ variant }} variant [1].
+
+  It provides the ROS {{ versionmap[ros_distro] }} {{ ros_distro }} stack to other snaps to that use it.
+  It share the ROS {{ versionmap[ros_distro] }} {{ ros_distro }} libraries, components and executables
+  through the content interface.
+  This helps reduce the size of snaps and helps developers to easily snap ROS {{ versionmap[ros_distro] }} {{ ros_distro }} applications.
+
+  *For users*
+
+  This snap is automatically installed and removed when needed.
+  Manually adding or removing this snap is not recommended and might break things.
+
+  If you are having issues with snaps using ROS, please contact the experts on the Snapcraft forum [2].
+
+  *For developers*
+
+  The `ros` extensions are the recommended way to use this in your own snap [3].
+  Find out how to do so in the documentation [4].
+  You can report issues with this content snap on GitHub [5] where the source code is available [6].
+
 {% if versionmap[ros_distro] == '1' %}
   [1] https://ros.org/reps/rep-0150.html
 {% else %}
   [1] https://ros.org/reps/rep-2001.html
 {% endif %}
+  [2] https://forum.snapcraft.io/
+  [3] https://snapcraft.io/docs/supported-extensions
+  [4] https://ubuntu.com/robotics/docs/ros-deployment-with-snaps-part-4
+  [5] https://github.com/ubuntu-robotics/ros-content-sharing-snaps/issues
+  [6] https://github.com/ubuntu-robotics/ros-content-sharing-snaps
+
 grade: stable
 confinement: strict
 base: {{ coremap[ros_distro] }}

--- a/templates/snapcraft.yaml.j2
+++ b/templates/snapcraft.yaml.j2
@@ -38,11 +38,13 @@ package-repositories:
 architectures:
   - build-on: {{ architecture }}
 
+{% if dev is not defined or not dev | bool -%}
 slots:
   ros-{{ ros_distro }}:
     content: ros-{{ ros_distro }}
     interface: content
     read: [/]
+{% endif %}
 
 parts:
 {%- if dev is defined and dev | bool %}

--- a/templates/snapcraft.yaml.j2
+++ b/templates/snapcraft.yaml.j2
@@ -2,6 +2,12 @@
 {%- set distromap={'noetic':'focal', 'foxy':'focal', 'humble':'jammy'} -%}
 {%- set pluginmap={'noetic':'catkin', 'foxy':'colcon', 'humble':'colcon'} -%}
 {%- set versionmap={'noetic':'1', 'foxy':'2', 'humble':'2'} -%}
+{%- set slotmap={
+  'noetic':["ros-core", "ros-base", "robot", "desktop"],
+  'foxy':["ros-core", "ros-base", "desktop"],
+  'humble':["ros-core", "ros-base", "desktop"],
+  }
+-%}
 {%- set ros = 'ros' if versionmap[ros_distro] == '1' else 'ros2' -%}
 {%- set devsuffix = '-dev' if dev is defined and dev | bool else '' -%}
 {%- set snapname = "ros-" + ros_distro + "-" + variant + devsuffix -%}
@@ -40,11 +46,13 @@ architectures:
 
 {% if dev is not defined or not dev | bool -%}
 slots:
-  ros-{{ ros_distro }}:
-    content: ros-{{ ros_distro }}
+{%- for slot in slotmap[ros_distro][:slotmap[ros_distro].index(variant)+1] %}
+  {{ "ros-" + ros_distro + "-" + slot}}:
+    content: {{ "ros-" + ros_distro + "-" + slot}}
     interface: content
     read: [/]
-{% endif %}
+{%- endfor -%}
+{%- endif %}
 
 parts:
 {%- if dev is defined and dev | bool %}

--- a/templates/snapcraft.yaml.j2
+++ b/templates/snapcraft.yaml.j2
@@ -12,9 +12,11 @@ summary: The ROS {{ versionmap[ros_distro] }} {{ ros_distro }} {{ variant }} var
 description: |
   This snap contains the ROS {{ ros_distro }} {{ variant }} variant [1].
   It is meant to be consumed as a stage or build snap.
-
+{% if versionmap[ros_distro] == '1' %}
   [1] https://ros.org/reps/rep-0150.html
-
+{% else %}
+  [1] https://ros.org/reps/rep-2001.html
+{% endif %}
 grade: stable
 confinement: strict
 base: {{ coremap[ros_distro] }}

--- a/templates/snapcraft.yaml.j2
+++ b/templates/snapcraft.yaml.j2
@@ -19,7 +19,7 @@ description: |
   This snap contains the ROS {{ versionmap[ros_distro] }} {{ ros_distro }} {{ variant }} variant [1].
 
   It provides the ROS {{ versionmap[ros_distro] }} {{ ros_distro }} stack to other snaps to that use it.
-  It share the ROS {{ versionmap[ros_distro] }} {{ ros_distro }} libraries, components and executables
+  It shares the ROS {{ versionmap[ros_distro] }} {{ ros_distro }} libraries, components and executables
   through the content interface.
   This helps reduce the size of snaps and helps developers to easily snap ROS {{ versionmap[ros_distro] }} {{ ros_distro }} applications.
 


### PR DESCRIPTION
This PR adapts the template as described in [this](https://forum.snapcraft.io/t/request-for-global-autoconnect-of-ros-foundation-snaps/38851/8) thread. That is, slots are renamed as the snap itself, making them more specific and thus avoid an erroneous autoconnection (e.g. plugging to core when you really expect desktop...).

It also removes the slot for '-dev' snaps since it isn't necessary.